### PR TITLE
Remove unused local variables in Servicenow::Change

### DIFF
--- a/lib/servicenow/change.rb
+++ b/lib/servicenow/change.rb
@@ -16,7 +16,7 @@ module Servicenow
         work_notes: notes
       }
 
-      response = client.send_request(url, query, :patch)
+      client.send_request(url, query, :patch)
       change
     end
 
@@ -33,7 +33,7 @@ module Servicenow
         work_start: Time.now.utc
       }.merge(extra)
 
-      response = client.send_request(url, query, :patch)
+      client.send_request(url, query, :patch)
       change
     end
 
@@ -50,7 +50,7 @@ module Servicenow
         work_end: Time.now.utc
       }.merge(extra)
 
-      response = client.send_request(url, query, :patch)
+      client.send_request(url, query, :patch)
       change
     end
 


### PR DESCRIPTION
Hi, This PR is a small improve.

## Overview

I separated db9b199 from PR #4 in line with a @rubyisbeautiful's wishes .

 - The local variable ’response’ was deleted because it is unused in the method.

Thank you.